### PR TITLE
Fix deploy workflow command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Deploy Worker
-        run: pnpm deploy
+        run: pnpm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Fix `pnpm deploy` → `pnpm run deploy` in GitHub Actions workflow
- `pnpm deploy` is a built-in pnpm monorepo command, not a script runner — it fails with `ERR_PNPM_CANNOT_DEPLOY` outside a workspace

## Test plan
- [ ] Merge to main triggers deploy workflow
- [ ] `pnpm run deploy` executes `wrangler deploy` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)