### PR TITLE
Add copy buttons for code blocks and raw markdown

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -494,6 +494,12 @@ body {
   flex-shrink: 0;
 }
 
+.viewer-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* ── Markdown body styling ───────────────────────────────────────────────── */
 
 .markdown-body {
@@ -569,6 +575,30 @@ body {
   background: none;
   font-size: 0.8125rem;
   line-height: 1.6;
+}
+
+.code-copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.markdown-body pre:hover .code-copy-btn {
+  opacity: 1;
+}
+
+.code-copy-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text);
 }
 
 .markdown-body table {

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,10 @@
         <div id="viewer-area" class="viewer-area" hidden>
           <div class="viewer-toolbar">
             <button id="back-btn" class="text-btn">&larr; Back</button>
-            <button id="delete-file-btn" class="text-btn danger">Delete</button>
+            <div class="viewer-toolbar-right">
+              <button id="copy-md-btn" class="text-btn" hidden>Copy Markdown</button>
+              <button id="delete-file-btn" class="text-btn danger">Delete</button>
+            </div>
           </div>
           <article id="rendered-output" class="markdown-body"></article>
         </div>


### PR DESCRIPTION
## Summary
- **Code block copy** (#6): Each fenced code block shows a "Copy" button on hover (top-right corner) that copies the snippet to clipboard with "Copied!" feedback
- **Copy Markdown** (#11): New "Copy Markdown" button in the viewer toolbar copies the raw markdown source to clipboard

Closes #6, closes #11

## Test plan
- [ ] View a file with fenced code blocks — hover over a `<pre>` block and verify the Copy button appears
- [ ] Click the Copy button — verify clipboard contains the code and button shows "Copied!"
- [ ] Click "Copy Markdown" in the viewer toolbar — verify clipboard contains the raw markdown source
- [ ] Navigate back to the input area — verify the Copy Markdown button is hidden
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)