### PR TITLE
fix: timestamp scroll and code copy button positioning

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -785,6 +785,11 @@ body {
   margin-left: auto;
 }
 
+.viewer-scroll {
+  flex: 1;
+  overflow-y: auto;
+}
+
 .viewer-created {
   font-size: 0.75rem;
   color: var(--text-tertiary);
@@ -795,12 +800,8 @@ body {
 /* ── Markdown body styling ───────────────────────────────────────────────── */
 
 .markdown-body {
-  padding: 32px 24px;
-  max-width: 860px;
-  margin: 0 auto;
+  padding: 32px max(24px, calc((100% - 860px) / 2));
   width: 100%;
-  overflow-y: auto;
-  flex: 1;
   line-height: 1.7;
   font-size: 1rem;
 }
@@ -853,8 +854,13 @@ body {
   font-family: "SF Mono", "Cascadia Mono", "Fira Code", monospace;
 }
 
-.markdown-body pre {
+.pre-wrapper {
+  position: relative;
   margin-bottom: 1em;
+}
+
+.markdown-body pre {
+  margin-bottom: 0;
   border-radius: var(--radius);
   overflow-x: auto;
   background: var(--code-bg);
@@ -885,7 +891,7 @@ body {
 }
 
 @media (hover: hover) {
-  .markdown-body pre:hover .code-copy-btn {
+  .pre-wrapper:hover .code-copy-btn {
     opacity: 1;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -116,8 +116,10 @@
               <button id="delete-file-btn" class="text-btn danger">Delete</button>
             </div>
           </div>
-          <div id="viewer-created" class="viewer-created" hidden></div>
-          <article id="rendered-output" class="markdown-body"></article>
+          <div class="viewer-scroll">
+            <div id="viewer-created" class="viewer-created" hidden></div>
+            <article id="rendered-output" class="markdown-body"></article>
+          </div>
         </div>
       </main>
     </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -656,7 +656,11 @@ function renderMarkdown(content, title, id) {
 
 function addCodeCopyButtons() {
   for (const pre of renderedOutput.querySelectorAll('pre')) {
-    pre.style.position = 'relative';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'pre-wrapper';
+    pre.parentNode.insertBefore(wrapper, pre);
+    wrapper.appendChild(pre);
+
     const btn = document.createElement('button');
     btn.className = 'code-copy-btn';
     btn.textContent = 'Copy';
@@ -666,7 +670,7 @@ function addCodeCopyButtons() {
       btn.textContent = 'Copied!';
       setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
     });
-    pre.appendChild(btn);
+    wrapper.appendChild(btn);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes two viewer bugs: the created-at timestamp staying pinned above scrollable content (#47), and the code block copy button scrolling horizontally off-screen with long code lines (#48). Also improves the scroll container to span the full viewport width on wide screens.

## Changes

- Wrap `#viewer-created` and `#rendered-output` in a `.viewer-scroll` container so the timestamp scrolls naturally with the document content
- Wrap each `<pre>` in a `.pre-wrapper` div so the copy button stays anchored to the visible top-right corner regardless of horizontal scroll
- Replace `max-width: 860px; margin: 0 auto` on `.markdown-body` with `padding: 32px max(24px, calc((100% - 860px) / 2))` so the scroll area spans full viewport width while preserving readable line lengths

## Testing

- [x] Tested locally with `pnpm dev`
- [x] Verified on mobile viewport
- [x] Checked light and dark themes
- [x] Verified timestamp scrolls out of view with content
- [x] Verified copy button stays anchored during horizontal code scroll
- [x] Verified scroll container spans full viewport width at 1400px
- [x] Verified copy button click works (shows "Copied!" feedback)

Closes #47
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)